### PR TITLE
fix: always trigger pipelines on main merge

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths:
-      - src/Polygame.Android/**
-      - src/Polygame.Core/**
   pull_request:
     paths:
       - src/Polygame.Android/**

--- a/.github/workflows/desktopgl.yml
+++ b/.github/workflows/desktopgl.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths:
-      - src/Polygame.DesktopGL/**
-      - src/Polygame.Core/**
   pull_request:
     paths:
       - src/Polygame.DesktopGL/**

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths:
-      - src/Polygame.iOS/**
-      - src/Polygame.Core/**
   pull_request:
     paths:
       - src/Polygame.iOS/**

--- a/.github/workflows/windowsdx.yml
+++ b/.github/workflows/windowsdx.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths:
-      - src/Polygame.WindowsDX/**
-      - src/Polygame.Core/**
   pull_request:
     paths:
       - src/Polygame.WindowsDX/**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build automation so Android runs on relevant pull requests, while desktop, iOS, and Windows builds now run more consistently on main-branch and version-tag pushes.
  * Kept manual workflow runs available.
  * Preserved existing pull request path filtering where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->